### PR TITLE
orjson_compatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -20,7 +20,7 @@ classifiers = [
 requires-python = ">=3.11"
 dependencies = [
     "lark==1.2.2",
-    "orjson==3.10.1",
+    "orjson>=3.10,<3.12",
     "aiohttp==3.10.11",
     "enumclasses @ https://github.com/RebelMouseTeam/enumclasses/archive/refs/tags/v1.1.7.tar.gz"
 ]


### PR DESCRIPTION
Allow orjson version to be chosen based on monolith instead of forcing it on library level [DD-1949]

[DD-1949]: https://rebelmouse.atlassian.net/browse/DD-1949?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ